### PR TITLE
Patch bugfix

### DIFF
--- a/src/client.py
+++ b/src/client.py
@@ -78,6 +78,7 @@ if __name__ == "__main__":
     audio.list_speakers(True)
     audio.get_default_microphone(True)
     audio.get_default_speakers(True)
+    audio.get_default_host_api(True)
 
     connector = Client(target)
     connector.mainloop()


### PR DESCRIPTION
- client now prints the host API of the system

- Playback now plays in the proper no. of channels for the given playback device

- the list_...() series of functions now list devices managed by the system audio API instead of arbitrary secondary API.